### PR TITLE
Add functionality to add comment for all update jobs.

### DIFF
--- a/src/main/java/com/gengo/client/GengoClient.java
+++ b/src/main/java/com/gengo/client/GengoClient.java
@@ -412,6 +412,17 @@ public class GengoClient extends JsonHttpApi
      */
     public JSONObject reviseTranslationJobs(HashMap<Integer, String> jobs) throws GengoException
     {
+        return reviseTranslationJobs(jobs, null);
+    }
+
+    /**
+     * Revise jobs with revision comment.
+     * @param HashMap instance which consists of job ID and comment text
+     * @param String comment for all jobs
+     * @throws GengoException
+     */
+    public JSONObject reviseTranslationJobs(HashMap<Integer, String> jobs, String comment) throws GengoException
+    {
         try
         {
             String url = getBaseUrl() + "translate/jobs";
@@ -427,6 +438,9 @@ public class GengoClient extends JsonHttpApi
             }
             // [end] Generate 'job_ids' parameter.
             data.put("job_ids", job_ids);
+            if (comment != null) {
+            	data.put("comment", comment);
+            }
             return call(url, HttpMethod.PUT, data);
         } catch (JSONException e)
         {
@@ -465,6 +479,17 @@ public class GengoClient extends JsonHttpApi
      */
     public JSONObject rejectTranslationJobs(List<Rejection> jobs) throws GengoException
     {
+        return rejectTranslationJobs(jobs, null);
+    }
+
+    /**
+     * Reject jobs with collateral attributes.
+     * @param jobs list of Rejection instance
+     * @param String comment for all jobs
+     * @throws GengoException
+     */
+    public JSONObject rejectTranslationJobs(List<Rejection> jobs, String comment) throws GengoException
+    {
         try
         {
             String url = getBaseUrl() + "translate/jobs";
@@ -475,6 +500,9 @@ public class GengoClient extends JsonHttpApi
                 iJobs.put(job.toJSONObject());
             }
             data.put("job_ids", iJobs);
+            if (comment != null) {
+            	data.put("comment", comment);
+            }
             return call(url, HttpMethod.PUT, data);
         } catch (JSONException e)
         {


### PR DESCRIPTION
Carmi asked me that why gengo-java client doesn't have functionality like below even gengo-php client works. So I committed this to fix the difference.

```php
require_once 'gengo-php/init.php';
$api_key = 'your_public_key';
$private_key = 'your_private_key';
$comment = 'This is an all comment!';
$jobs = array(array('job_id' => 17151745,
                    'comment' => 'This comment is alone.'),
              array('job_id' => 17151746));
// Get an instance of Jobs Client
$job_client = Gengo_Api::factory('jobs', $api_key, $private_key);
// revise
$job_client->revise($jobs, 'v2', $comment);
// get response
$body = $job_client->getResponseBody();
var_dump($body);
```